### PR TITLE
Add check for repositoryPath parameter in nuget.config

### DIFF
--- a/ProtobufGenerator.csproj
+++ b/ProtobufGenerator.csproj
@@ -164,6 +164,7 @@ PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
     <Reference Include="System.Xml">
       <Name>System.XML</Name>
     </Reference>
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="VSLangProj">
     </Reference>
     <Reference Include="VSLangProj2">

--- a/packages.config
+++ b/packages.config
@@ -23,4 +23,5 @@
   <package id="Microsoft.VisualStudio.Utilities" version="14.0.23205" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Validation" version="14.0.50702" targetFramework="net45" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Sometimes the desired `Google.Protobuf.Tools` package can be found in a custom NuGet `repositoryPath` folder, which may be specified per solution. For example, in Unity3D project, it is convenient to store NuGet packages somewhere in `Assets/Plugins`.
Here's a change that takes `nuget.config` contents into account.