### PR TITLE
feature: Show error message in VS error window when protoc output error.

### DIFF
--- a/GenerateFromProto.cs
+++ b/GenerateFromProto.cs
@@ -31,6 +31,11 @@ namespace Knacka.Se.ProtobufGenerator
 
             var exitCode = RunProtoc(_protocPath, $"--csharp_out={outdir} --proto_path={infileDir} {infile}", infileDir, out stdout, out stderr);
 
+            if (!string.IsNullOrEmpty(stderr))
+            {
+                throw new InvalidOperationException(stderr);
+            }
+
             var files = Directory.GetFiles(outdir);
             if (files != null && files.Any())
             {


### PR DESCRIPTION
`stderr `out from `RunProtoc()` is not used but is very informative for debugging. If error occurs on protoc, throwing exception with `stderr `message so that `GeneratorError()` can catch it.